### PR TITLE
FIX: Put quotes around the uri strings in the repr.

### DIFF
--- a/suitcase/mongo_layout1/__init__.py
+++ b/suitcase/mongo_layout1/__init__.py
@@ -100,5 +100,5 @@ class Serializer(event_model.DocumentRouter):
     def __repr__(self):
         # Display connection info in eval-able repr.
         return (f'{type(self).__name__}('
-                f'metadatastore_uri={self._metadatastore_uri}, '
-                f'asset_registry_uri={self._asset_registry_uri})')
+                f'metadatastore_uri={self._metadatastore_uri!r}, '
+                f'asset_registry_uri={self._asset_registry_uri!r})')

--- a/suitcase/mongo_layout2/__init__.py
+++ b/suitcase/mongo_layout2/__init__.py
@@ -57,4 +57,4 @@ class Serializer(event_model.DocumentRouter):
 
     def __repr__(self):
         # Display connection info in eval-able repr.
-        return f'{type(self).__name__}(uri={self._uri})'
+        return f'{type(self).__name__}(uri={self._uri!r})'


### PR DESCRIPTION
So the result looks like this:

```py
In [2]: serializer = suitcase.mongo_layout1.Serializer('mongodb://localhost:2701
   ...: 7/metadatastore', 'mongodb://localhost:27017/asset_registry')

In [3]: serializer
Out[3]: Serializer(metadatastore_uri='mongodb://localhost:27017/metadatastore', asset_registry_uri='mongodb://localhost:27017/asset_registry')
```