### PR TITLE
BLD: Make tests a package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,9 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     long_description=readme,
-    packages=['suitcase.mongo_layout1', 'suitcase.mongo_layout2'],
+    packages=['suitcase.mongo_layout1', 'suitcase.mongo_layout1.tests',
+              'suitcase.mongo_layout2',  # TODO Add tests package when it exists.
+              ],
     entry_points={
         'console_scripts': [
             # 'some.module:some_function',


### PR DESCRIPTION
This is just some belated clean to organize `suitcase-mongo` the same as other suitcase pages: tests should be proper subpackage that is importable.